### PR TITLE
added input via actions to enable remapping

### DIFF
--- a/character/character_controller.gd
+++ b/character/character_controller.gd
@@ -35,13 +35,13 @@ var _last_motor := Vector3()
 func _physics_process(delta):
 	var motor := Vector3()
 	
-	if Input.is_key_pressed(KEY_W):
+	if Input.is_action_pressed("forward"):
 		motor += Vector3(0, 0, -1)
-	if Input.is_key_pressed(KEY_S):
+	if Input.is_action_pressed("back"):
 		motor += Vector3(0, 0, 1)
-	if Input.is_key_pressed(KEY_A):
+	if Input.is_action_pressed("left"):
 		motor += Vector3(-1, 0, 0)
-	if Input.is_key_pressed(KEY_D):
+	if Input.is_action_pressed("right"):
 		motor += Vector3(1, 0, 0)
 	
 	var character_body := _get_body()
@@ -147,31 +147,29 @@ func _process_actions():
 
 
 func _unhandled_input(event):
-	if event is InputEventKey:
-		if event.pressed and not event.is_echo():
-			match event.scancode:
-				KEY_SPACE:
-					var body := _get_body()
-					body.jump()
-				KEY_E:
-					_interact_cmd = true
-				KEY_F:
-					_flashlight.visible = not _flashlight.visible
-					if _flashlight.visible:
-						_audio.play_light_on()
-					else:
-						_audio.play_light_off()
-				KEY_T:
-					_waypoint_cmd = true
-					
-	elif event is InputEventMouseButton:
-		if event.pressed:
-			match event.button_index:
-				BUTTON_LEFT:
-					_dig_cmd = true
-				BUTTON_RIGHT:
-					_build_cmd = true
 
+	if event is InputEventMouseMotion:
+		return
+	if event.is_echo():
+		return
+
+	if event.is_action_pressed("primary"):
+		_dig_cmd = true
+	elif event.is_action_pressed("secondary"):
+		_build_cmd = true
+	elif event.is_action_pressed("jump"):
+		var body := _get_body()
+		body.jump()
+	elif event.is_action_pressed("interact"):
+		_interact_cmd = true
+	elif event.is_action_pressed("flashlight"):
+		_flashlight.visible = not _flashlight.visible
+		if _flashlight.visible:
+			_audio.play_light_on()
+		else:
+			_audio.play_light_off()
+	elif event.is_action_pressed("waypoint"):
+		_waypoint_cmd = true
 
 func _interact():
 	var character_body := _get_body()

--- a/project.godot
+++ b/project.godot
@@ -64,6 +64,74 @@ config/icon="res://icon.png"
 
 DDD="*res://addons/zylann.debug_draw/debug_draw.gd"
 
+[input]
+
+forward={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":87,"unicode":0,"echo":false,"script":null)
+ ]
+}
+back={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":83,"unicode":0,"echo":false,"script":null)
+ ]
+}
+left={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":65,"unicode":0,"echo":false,"script":null)
+ ]
+}
+right={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":68,"unicode":0,"echo":false,"script":null)
+ ]
+}
+primary={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
+secondary={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":2,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
+run={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":16777240,"unicode":0,"echo":false,"script":null)
+ ]
+}
+jump={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":32,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ship_speed={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":32,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ship_brake={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":32,"unicode":0,"echo":false,"script":null)
+ ]
+}
+interact={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":69,"unicode":0,"echo":false,"script":null)
+ ]
+}
+flashlight={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":70,"unicode":0,"echo":false,"script":null)
+ ]
+}
+waypoint={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":84,"unicode":0,"echo":false,"script":null)
+ ]
+}
+
 [rendering]
 
 environment/default_clear_color=Color( 0, 0, 0, 1 )

--- a/ship/ship_controller.gd
+++ b/ship/ship_controller.gd
@@ -26,25 +26,25 @@ func _process(delta: float):
 	
 	var motor := Vector3()
 	
-	if Input.is_key_pressed(KEY_S):
+	if Input.is_action_pressed("back"):
 		motor.z -= 1
-	if Input.is_key_pressed(KEY_W) or Input.is_key_pressed(KEY_Z):
+	if Input.is_action_pressed("forward") or Input.is_key_pressed(KEY_Z):
 		motor.z += 1
 #	if Input.is_key_pressed(KEY_A):
 #		motor.x -= 1
 #	if Input.is_key_pressed(KEY_D):
 #		motor.x += 1
-	if Input.is_key_pressed(KEY_SPACE):
+	if Input.is_action_pressed("ship_speed"):
 		motor.y += 1
-	if Input.is_key_pressed(KEY_SHIFT):
+	if Input.is_action_pressed("ship_brake"):
 		motor.y -= 1
 
-	if Input.is_key_pressed(KEY_A):
+	if Input.is_action_pressed("left"):
 		_turn_cmd.z -= keyboard_turn_sensitivity
-	if Input.is_key_pressed(KEY_D):
+	if Input.is_action_pressed("right"):
 		_turn_cmd.z += keyboard_turn_sensitivity
 	
-	_ship.set_superspeed_cmd(Input.is_key_pressed(KEY_SPACE))
+	_ship.set_superspeed_cmd(Input.is_action_pressed("ship_speed"))
 	
 	_turn_cmd.x = clamp(_turn_cmd.x, -1.0, 1.0)
 	_turn_cmd.y = clamp(_turn_cmd.y, -1.0, 1.0)
@@ -125,11 +125,8 @@ func _input(event):
 		_turn_cmd.x += cmd.x
 		_turn_cmd.y += cmd.y
 	
-	elif event is InputEventKey:
-		if event.pressed:
-			match event.scancode:
-				KEY_E:
-					_exit_ship_cmd = true
+	elif event.is_action_pressed("interact") && !event.is_echo():
+		_exit_ship_cmd = true
 
 
 # TODO Temporary, need to replace this with a rocket launcher


### PR DESCRIPTION
Had a  lot of fun testing this demo, I made a small change to allow me to re-map the controllers. This adds input actions in the project settings, and changes the controller code to use the actions instead of the input events directly. Only played in godot3, sorry